### PR TITLE
Pass mypy

### DIFF
--- a/jaraco/crypto/cert.py
+++ b/jaraco/crypto/cert.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import ctypes
+from typing import ClassVar
 
 from .support import find_library
 
@@ -50,7 +53,7 @@ lib.BN_bn2hex.restype = ctypes.c_char_p
 
 
 class X509(ctypes.Structure):
-    _fields_ = []  # type: ignore
+    _fields_: ClassVar[list[tuple[str, type[ctypes._CData]]]] = []
 
     def get_serial_number(self):
         asn1_i = lib.X509_get_serialNumber(ctypes.byref(self))

--- a/jaraco/crypto/cipher.py
+++ b/jaraco/crypto/cipher.py
@@ -104,8 +104,8 @@ class Cipher(ctypes.Structure):
         return b"".join(self.out_data)
 
 
-evp.get_cipherbyname.argtypes = (ctypes.c_char_p,)  # type: ignore
-evp.get_cipherbyname.restype = ctypes.POINTER(CipherType)  # type: ignore
+evp.get_cipherbyname.argtypes = (ctypes.c_char_p,)
+evp.get_cipherbyname.restype = ctypes.POINTER(CipherType)
 
 
 # https://www.openssl.org/docs/man3.1/man3/EVP_CipherInit_ex.html
@@ -130,16 +130,16 @@ _final_args = (
     ctypes.c_char_p,  # out[m]
     ctypes.POINTER(ctypes.c_int),  # outl
 )
-evp.EncryptInit_ex.argtypes = (  # type: ignore
-    evp.DecryptInit_ex.argtypes  # type: ignore
-) = _init_args[:2] + _init_args[3:5]
-evp.CipherInit_ex.argtypes = _init_args  # type: ignore
-evp.EncryptUpdate.argtypes = (  # type: ignore
-    evp.DecryptUpdate.argtypes  # type: ignore
-) = evp.CipherUpdate.argtypes = _update_args  # type: ignore
-evp.EncryptFinal_ex.argtypes = (  # type: ignore
-    evp.DecryptFinal_ex.argtypes  # type: ignore
-) = evp.CipherFinal_ex.argtypes = _final_args  # type: ignore
+evp.EncryptInit_ex.argtypes = evp.DecryptInit_ex.argtypes = (
+    _init_args[:2] + _init_args[3:5]
+)
+evp.CipherInit_ex.argtypes = _init_args
+evp.EncryptUpdate.argtypes = evp.DecryptUpdate.argtypes = evp.CipherUpdate.argtypes = (
+    _update_args
+)
+evp.EncryptFinal_ex.argtypes = evp.DecryptFinal_ex.argtypes = (
+    evp.CipherFinal_ex.argtypes
+) = _final_args
 
 evp.lib.EVP_CIPHER_CTX_new.argtypes = None
 evp.lib.EVP_CIPHER_CTX_new.restype = ctypes.POINTER(Cipher)

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,3 +13,5 @@ explicit_package_bases = True
 disable_error_code =
 	# Disable due to many false positives
 	overload-overlap,
+	# This package has too many dynamically assigned attributes
+	attr-defined,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,3 @@ namespaces = true
 
 
 [tool.setuptools_scm]
-
-
-[tool.pytest-enabler.mypy]
-# Disabled due to jaraco/skeleton#143


### PR DESCRIPTION
Ref: https://github.com/jaraco/skeleton/issues/143

There's two approaches here, depending on what you prefer.
1. Either add `attr-defined` to the previous `type: ignore` `(and more if annotations are added, causing mypy to validate more code).
2. Disable `attr-defined` checks for this package.